### PR TITLE
Added /spawn mobcaps command

### DIFF
--- a/src/main/java/quickcarpet/QuickCarpet.java
+++ b/src/main/java/quickcarpet/QuickCarpet.java
@@ -39,6 +39,7 @@ public class QuickCarpet implements ModInitializer {
         CounterCommand.register(dispatcher);
         PlayerCommand.register(dispatcher);
         LogCommand.register(dispatcher);
+        SpawnCommand.register(dispatcher);
     }
 
     @Override

--- a/src/main/java/quickcarpet/QuickCarpetSettings.java
+++ b/src/main/java/quickcarpet/QuickCarpetSettings.java
@@ -59,6 +59,7 @@ public class QuickCarpetSettings {
                         .isACommand().boolAccelerate().defaultFalse(),
                 rule("commandPlayer", "commands", "Enables /player command to control/spawn players").isACommand(),
                 rule("commandLog",    "commands", "Enables /log command to monitor events in the game via chat and overlays").isACommand(),
+                rule("commandSpawn",  "commands", "Enables /spawn command for spawn tracking").isACommand(),
                 rule("explosionNoBlockDamage", "tnt", "Explosions won't destroy blocks"),
         };
         for (CarpetSettingEntry rule : RuleList) {

--- a/src/main/java/quickcarpet/commands/SpawnCommand.java
+++ b/src/main/java/quickcarpet/commands/SpawnCommand.java
@@ -1,0 +1,53 @@
+package quickcarpet.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.minecraft.command.arguments.DimensionArgumentType;
+import net.minecraft.entity.EntityCategory;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.TextComponent;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.dimension.DimensionType;
+import quickcarpet.QuickCarpetSettings;
+import quickcarpet.mixin.IServerChunkManager;
+import quickcarpet.utils.Messenger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.minecraft.server.command.CommandManager.literal;
+import static net.minecraft.server.command.CommandManager.argument;
+
+public class SpawnCommand {
+    public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+        LiteralArgumentBuilder<ServerCommandSource> builder = literal("spawn").
+                requires((player) -> QuickCarpetSettings.getBool("commandSpawn")).
+                then(literal("mobcaps").
+                    executes(c -> sendMobcaps(c.getSource(), null)).
+                    then(argument("dimension", DimensionArgumentType.create()).
+                        executes(c -> sendMobcaps(c.getSource(), c.getArgument("dimension", DimensionType.class)))
+                    )
+                );
+        dispatcher.register(builder);
+    }
+
+    private static int sendMobcaps(ServerCommandSource source, DimensionType dimension) {
+        if (dimension == null) dimension = source.getWorld().getDimension().getType();
+        ServerWorld world = source.getMinecraftServer().getWorld(dimension);
+        Object2IntMap<EntityCategory> mobs = world.getMobCountsByCategory();
+        List<TextComponent> lst = new ArrayList<>();
+        lst.add(Messenger.s(String.format("Mobcaps for %s:", Registry.DIMENSION.getId(dimension))));
+        int chunks = ((IServerChunkManager) world.method_14178()).getTicketManager().getLevelCount();
+        for (EntityCategory category : EntityCategory.values()) {
+            int cur = mobs.getOrDefault(category, 0);
+            int max = chunks * category.getSpawnCap() / (17 * 17);
+            lst.add(Messenger.c(String.format("w   %s: ", category),
+                (cur+max==0)?"g -/-":String.format("%s %d/%d", (cur >= max)?"r":((cur >= 8*max/10)?"y":"l") ,cur, max)
+            ));
+        }
+        Messenger.send(source, lst);
+        return 1;
+    }
+}

--- a/src/main/java/quickcarpet/mixin/IServerChunkManager.java
+++ b/src/main/java/quickcarpet/mixin/IServerChunkManager.java
@@ -1,0 +1,12 @@
+package quickcarpet.mixin;
+
+import net.minecraft.server.world.ChunkTicketManager;
+import net.minecraft.server.world.ServerChunkManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerChunkManager.class)
+public interface IServerChunkManager {
+    @Accessor("ticketManager")
+    ChunkTicketManager getTicketManager();
+}

--- a/src/main/resources/quickcarpet.mixins.json
+++ b/src/main/resources/quickcarpet.mixins.json
@@ -13,7 +13,8 @@
     "MixinPlayerManager",
     "MixinPrimedTNTEntity",
     "MixinMinecraftClient",
-    "MixinExplosion"
+    "MixinExplosion",
+    "IServerChunkManager"
   ],
   "client": [
     "MixinIntegratedServer"


### PR DESCRIPTION
Adds the ability to read the mobcaps and number of mobs filling them via `/spawn mobcaps`
`/spawn mobcaps set` is not supported