### PR TITLE
Added a feature to make soulsand renewable.

### DIFF
--- a/src/main/java/quickcarpet/mixin/LivingEntityMixin.java
+++ b/src/main/java/quickcarpet/mixin/LivingEntityMixin.java
@@ -1,0 +1,41 @@
+package quickcarpet.mixin;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.tag.BlockTags;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import quickcarpet.settings.Settings;
+
+@Mixin(LivingEntity.class)
+public abstract class LivingEntityMixin extends Entity {
+
+    public LivingEntityMixin(EntityType<?> entityType_1, World world_1) {
+        super(entityType_1, world_1);
+    }
+
+    @Inject(method="onDeath", at=@At(value="INVOKE", target="Lnet/minecraft/entity/damage/DamageSource;getAttacker()Lnet/minecraft/entity/Entity;", shift = At.Shift.BEFORE))
+    private void convertSandToSoulsand(DamageSource source, CallbackInfo ci)
+    {
+        if (!Settings.mobInFireConvertsSandToSoulsand) return;
+
+        BlockPos pos = new BlockPos(this.x, this.y, this.z);
+        BlockState statePos = this.world.getBlockState(pos);
+
+        BlockPos below = pos.down();
+        BlockState stateBelow = this.world.getBlockState(below);
+
+        if (statePos.getBlock() == Blocks.FIRE && stateBelow.getBlock().matches(BlockTags.SAND))
+        {
+            this.world.setBlockState(below, Blocks.SOUL_SAND.getDefaultState());
+        }
+    }
+}

--- a/src/main/java/quickcarpet/settings/Settings.java
+++ b/src/main/java/quickcarpet/settings/Settings.java
@@ -113,6 +113,9 @@ public class Settings {
     @Rule(desc = "Optimizes spawning", category = {OPTIMIZATIONS, EXPERIMENTAL})
     public static boolean optimizedSpawning = false;
 
+    @Rule(desc = "If a mob dies on sand by by fire the sand will convert into soul sand", category = {FEATURE, EXPERIMENTAL})
+    public static boolean mobInFireConvertsSandToSoulsand = false;
+
     public static void main(String[] args) throws FileNotFoundException {
         Bootstrap.initialize();
         MANAGER.parse();

--- a/src/main/java/quickcarpet/settings/Settings.java
+++ b/src/main/java/quickcarpet/settings/Settings.java
@@ -113,7 +113,7 @@ public class Settings {
     @Rule(desc = "Optimizes spawning", category = {OPTIMIZATIONS, EXPERIMENTAL})
     public static boolean optimizedSpawning = false;
 
-    @Rule(desc = "If a mob dies on sand by by fire the sand will convert into soul sand", category = {FEATURE, EXPERIMENTAL})
+    @Rule(desc = "If a living entity dies on sand with fire on top the sand will convert into soul sand", category = {FEATURE, EXPERIMENTAL})
     public static boolean mobInFireConvertsSandToSoulsand = false;
 
     public static void main(String[] args) throws FileNotFoundException {

--- a/src/main/resources/quickcarpet.mixins.json
+++ b/src/main/resources/quickcarpet.mixins.json
@@ -16,6 +16,7 @@
     "HopperBlockEntityMixin",
     "InfestedBlockMixin",
     "ItemEntityMixin",
+    "LivingEntityMixin",
     "MinecraftDedicatedServerMixin",
     "MinecraftServerMixin",
     "PistonBlockEntityMixin",


### PR DESCRIPTION
*read the following with a mythical explainer voice*

To create soul sand you need to burn a soul of a living entity into a block of sand.
So it is necessary to have a sand block as base on top of that you'll need a fire block
and last a living entity must be sacrificed on that combination only then it's soul will
be burned into the sand and become a soul sand.

The rule for this is "mobInFireConvertsSandToSoulsand".

I hope you like the description :-)