### PR TITLE
Fix obsidian dropping without proper tools

### DIFF
--- a/src/main/java/quickcarpet/mixin/renewableLava/BlocksMixin.java
+++ b/src/main/java/quickcarpet/mixin/renewableLava/BlocksMixin.java
@@ -26,6 +26,6 @@ public class BlocksMixin {
             target = "Lnet/minecraft/block/Blocks;register(Ljava/lang/String;Lnet/minecraft/block/Block;)Lnet/minecraft/block/Block;",
             ordinal = 0))
     private static Block registerObsidian(String id, Block obsidian) {
-        return register("obsidian", new ObsidianBlock(Block.Settings.of(Material.STONE, MaterialColor.BLACK).strength(50.0F, 1200.0F)));
+        return register("obsidian", new ObsidianBlock(Block.Settings.of(Material.STONE, MaterialColor.BLACK).requiresTool().strength(50.0F, 1200.0F)));
     }
 }


### PR DESCRIPTION
In 1.16, vanilla code changed so in the block declarations you have to specify that the block requires the tool in order for it to drop itself as an item.
This wasn't changed when updating QuickCarpet's mixins (BlocksMixin, for renewableLava), making obsidian drop with lower level tools.
See also gnembon/carpet-extra#115